### PR TITLE
fix: validate documentation URLs via urllib.parse

### DIFF
--- a/src/domain/rules/value_objects.py
+++ b/src/domain/rules/value_objects.py
@@ -10,6 +10,7 @@ from typing import ClassVar, Optional, Dict, Any, List
 from uuid import UUID
 import re
 import json
+from urllib.parse import urlparse
 
 
 class RuleStatus(Enum):
@@ -344,5 +345,7 @@ class RuleMetadata:
             raise ValueError("Description too long")
         
         # Validate documentation URL
-        if self.documentation_url and not self.documentation_url.startswith(("http://", "https://")):
-            raise ValueError("Invalid documentation URL")
+        if self.documentation_url:
+            parsed = urlparse(self.documentation_url)
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                raise ValueError("Invalid documentation URL")


### PR DESCRIPTION
## Summary
- parse `documentation_url` with `urllib.parse` to ensure `http`/`https` scheme and netloc

## Testing
- `pytest` *(fails: 53 failed, 246 passed, 1 skipped, 70 errors)*
- `pytest tests/unit/domain/test_value_objects.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2643786b8832a9bb620fbecd1b56f